### PR TITLE
adding newline between message and server name

### DIFF
--- a/src/components/otc/ListECS.vue
+++ b/src/components/otc/ListECS.vue
@@ -334,7 +334,7 @@
                     console.log('Tenant ' +server.tenant_id+' does not support server deletion')
                     return
                 }
-                let message = 'Do you really want to delete the following server?'
+                let message = 'Do you really want to delete the following server?<br/>'
                 message += server.name
                 this.$buefy.dialog.confirm({
                     title: 'Delete Server',


### PR DESCRIPTION
a newline has been added (as "`<br/>`") between the message and the server
name for the dialogbox/modal when deleting a server in OTC